### PR TITLE
Mountpoint cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ make etherlab
 #============================================
 #BE CAREFUL to specify the correct device name,
 #or you might end up deleting your host's root partition!
-./scripts/install.sh /dev/sdc
+./scripts/install.sh /dev/sdc /tmp/rootfs
 
 #install etherlab (optional):
 #=============================

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,14 +3,14 @@
 set -e
 set -o nounset
 
-if [ $# -ne 1 ]; then
-	echo -e "Usage:\n $0 <disk>\n\nexample:\n $0 /dev/sdc\n\n"
+if [ $# -ne 2 ]; then
+	echo -e "Usage:\n $0 <disk>\n\nexample:\n $0 /dev/sdc /tmp/rootfs\n\n"
 	exit -1
 fi
 
 DISK=$1
 PARTITION=${DISK}1
-ROOTFS_MOUNT=/media/rootfs
+ROOTFS_MOUNT=$2
 SCRIPT_PATH="`dirname \"$0\"`"
 
 ${SCRIPT_PATH}/10_install_mbr.sh ${DISK}


### PR DESCRIPTION
I noticed an inconsistency in the mount points. Examples are */tmp/rootfs* and the last command also says:

```sh
/scripts/52_install_etherlab.sh /tmp/rootfs
```

However in *install.sh* the mountpoint */media/rootfs* was hard-coded.