### PR TITLE
Add alternative building with docker

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,0 +1,10 @@
+FROM ubuntu:18.04
+COPY ./ /root/CX9020/
+WORKDIR /root/CX9020/
+RUN apt-get update && \
+    apt-get -yq install gpg sudo && \
+    tools/10_prepare_host_ubuntu1804.sh && \
+    git config --global user.name 'root' && \
+    git config --global user.email 'root@CX9020' && \
+    tools/prepare_uboot.sh v2019.10 && \
+    tools/prepare_kernel.sh v4.19-rt

--- a/README.md
+++ b/README.md
@@ -6,60 +6,84 @@ Please make sure to follow the steps below to create your microSD card.
 
 ## Installation
 ```
-#prepare your machine f.e.: 64-bit Ubuntu 18.04 LTS would require:
+# Get the repository
+#====================
+git clone https://github.com/Beckhoff/CX9020.git
+cd CX9020
+```
+
+If you have a supported distro, just call the appropriate script and prepare your system.
+```
+# Prepare your machine, e.g. 64-bit Ubuntu 18.04 LTS would require
 #=================================================================
 ./tools/10_prepare_host_ubuntu1804.sh
 
-# get the repository:
-#====================
-git clone https://github.com/Beckhoff/CX9020.git
-cd CX9020/
-
-#get and patch the u-boot sources:
+# Get and patch the u-boot sources
 #=================================
-./tools/prepare_uboot.sh v2019.10
+tools/prepare_uboot.sh v2019.10
 
-#build u-boot:
+# Get and patch a rt kernel
+#==========================
+tools/prepare_kernel.sh v4.19-rt
+
+```
+
+Otherwise you can leverage docker (assuming you have it already installed). In this case you need to have the SD card you want to write to already connected to the host system and parititioned, so it can be exposed to the container.
+```
+# Create an Ubuntu 18.04 LTS image ready for building
+#====================================================
+docker build -t cx9020 -f Dockerfile.builder .
+
+# Partition the destination SD card
+#==================================
+scripts/10_install_mbr.sh <SDCARD DEVICE>
+
+# Start the container
+#====================
+docker run -itw /root/CX9020/ --privileged --device=<SDCARD DEVICE>:<SDCARD DEVICE> cx9020 /bin/bash
+```
+
+In both cases, after preparing, follow the instructions below to build everything.
+```
+# Build u-boot
 #=============
 make uboot
 
-#get and patch a rt kernel:
-#==========================
-./tools/prepare_kernel.sh v4.19-rt
-
-#configure and build the kernel:
+# Configure and build the kernel
 #===============================
 make kernel
 
-#integrate acontis kernel extension atemsys from EC-Master SDK for emllCCAT support (optional):
+# Integrate acontis kernel extension atemsys from EC-Master SDK for emllCCAT support (optional)
 #==============================================================================================
-./tools/prepare_acontis.sh
+tools/prepare_acontis.sh
 make acontis
 
-#get and patch etherlab (optional):
-#==================================
-./tools/prepare_etherlab.sh
-
-#configure and build the etherlab (optional):
-#============================================
+# Build the etherlab master stack (optional)
+#===========================================
+tools/prepare_etherlab.sh
 make etherlab
 
-#prepare sdcard with a small debian rootfs:
-#============================================
-#BE CAREFUL to specify the correct device name,
-#or you might end up deleting your host's root partition!
-./scripts/install.sh /dev/sdc /tmp/rootfs
+# Prepare the SD card: pass --skip-partitioning if using docker
+#==============================================================
+scripts/install.sh --skip-partitioning <SDCARD DEVICE> /tmp/rootfs
 ```
+
 ## Usage
+
 The standard login on first boot:
 
 User:     root
-
 Password: root
 
 Please change the root password immediately and additionally create your own user.
 
+You can also access with SSH by using the following user:
+
+User:     cx9020
+Password: cx9020
+
 ### acontis EC-Master example (optional)
+
 To run the EcMasterDemo, extract the EC-Master SDK in /opt/EC-Master and start it from /opt/EC-Master/Bin/Linux/armv6-vfp-eabihf using:
 ```
 EcMasterDemo -ccat 1 1
@@ -67,4 +91,5 @@ EcMasterDemo -ccat 1 1
 See manuals in the SDK's "Doc" folder for how to build and run EC-Master applications
 
 ## History
+
 **TODO:** Write history

--- a/scripts/40_install_rootfs.sh
+++ b/scripts/40_install_rootfs.sh
@@ -25,6 +25,8 @@ chmod u+x ${ROOTFS_MOUNT}/install_rootfs_second_stage.sh
 /bin/mknod -m 0666 ${ROOTFS_MOUNT}/dev/null c 1 3
 /bin/mknod -m 0666 ${ROOTFS_MOUNT}/dev/random c 1 8
 /bin/mknod -m 0444 ${ROOTFS_MOUNT}/dev/urandom c 1 9
+
+update-binfmts --enable qemu-arm
 sudo chroot ${ROOTFS_MOUNT} /bin/bash -c "./install_rootfs_second_stage.sh"
 
 ${SCRIPT_PATH}/50_install_kernel.sh ${ROOTFS_MOUNT}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,8 +3,15 @@
 set -e
 set -o nounset
 
+if [ "$1" = '--skip-partitioning' ]; then
+	shift
+	partition=no
+else
+	partition=yes
+fi
+
 if [ $# -ne 2 ]; then
-	echo -e "Usage:\n $0 <disk>\n\nexample:\n $0 /dev/sdc /tmp/rootfs\n\n"
+	echo -e "Usage:\n $0 [--skip-partitioning] <disk> <mountpoint>\n\nexample:\n $0 /dev/sdc /tmp/rootfs\n\n"
 	exit -1
 fi
 
@@ -13,7 +20,7 @@ PARTITION=${DISK}1
 ROOTFS_MOUNT=$2
 SCRIPT_PATH="`dirname \"$0\"`"
 
-${SCRIPT_PATH}/10_install_mbr.sh ${DISK}
+[ "$partition" = 'yes' ] && ${SCRIPT_PATH}/10_install_mbr.sh ${DISK}
 ${SCRIPT_PATH}/20_install_uboot.sh ${DISK}
 ${SCRIPT_PATH}/30_install_partition.sh ${PARTITION} ${ROOTFS_MOUNT}
 ${SCRIPT_PATH}/40_install_rootfs.sh ${ROOTFS_MOUNT}

--- a/scripts/install_rootfs_second_stage.sh
+++ b/scripts/install_rootfs_second_stage.sh
@@ -11,5 +11,10 @@ cp -a /usr/share/zoneinfo/Europe/Berlin /etc/localtime
 
 dpkg --configure -a
 
+# Create `cx9020` user, so you can SSH into this box with it
+useradd -ms /bin/bash cx9020
+
 echo 'root:root' | chpasswd
+echo 'cx9020:cx9020' | chpasswd
+
 echo 'CX9020' > /etc/hostname


### PR DESCRIPTION
Instead of relying on a specific distro, allow the building process
inside a docker container. Because of privilege issues, the device needs
to be partitioned before on the host system.