### PR TITLE
rootfs: remove umount dev trap

### DIFF
--- a/scripts/40_install_rootfs.sh
+++ b/scripts/40_install_rootfs.sh
@@ -11,8 +11,6 @@ fi
 ROOTFS_MOUNT=$1
 SCRIPT_PATH="`dirname \"$0\"`"
 
-trap "sudo umount -f ${ROOTFS_MOUNT}/dev || true; exit" INT TERM EXIT
-
 #debian rootfs
 echo "Building debian rootfs..."
 


### PR DESCRIPTION
The `dev` binding has been removed in be955b7395ce.