### PR TITLE
kernel: fix net phy multiplex patch for kernel > 4.19.99

### DIFF
--- a/kernel-patches/0002-net-phy-multiplex-switch-phy-ports.patch
+++ b/kernel-patches/0002-net-phy-multiplex-switch-phy-ports.patch
@@ -8,6 +8,13 @@ integrate internal switches to provide more than one RJ45 port.
 Modify the generic phy driver to report 'link up' if any of the external
 ports senses a link. Add 'phy_driver.num_phys' module option to enable
 the multiplexing behaviour if set to > 1.
+
+In addition, since kernel 4.19.99, 'genphy_soft_reset' only write
+BMCR_RESET bit, which cause port 2 (X001) no becoming up after a soft-
+reboot. This was reverted to ensure this port became up after reboot.
+This fix also re-enable autonegociation in MII_BMCR registers as
+without it, port X001 stay 10Mb after we plug it if system has boot
+with port X000 connected only.
 ---
  drivers/net/phy/phy_device.c | 47 +++++++++++++++++++++++++++++++++++-
  1 file changed, 46 insertions(+), 1 deletion(-)
@@ -16,7 +23,7 @@ diff --git a/drivers/net/phy/phy_device.c b/drivers/net/phy/phy_device.c
 index 6144146aec29..072a6e515dfa 100644
 --- a/drivers/net/phy/phy_device.c
 +++ b/drivers/net/phy/phy_device.c
-@@ -42,6 +42,10 @@ MODULE_DESCRIPTION("PHY library");
+@@ -42,6 +42,10 @@
  MODULE_AUTHOR("Andy Fleming");
  MODULE_LICENSE("GPL");
  
@@ -27,7 +34,7 @@ index 6144146aec29..072a6e515dfa 100644
  void phy_device_free(struct phy_device *phydev)
  {
  	put_device(&phydev->mdio.dev);
-@@ -1643,6 +1647,32 @@ int genphy_read_status(struct phy_device *phydev)
+@@ -1651,6 +1655,32 @@
  }
  EXPORT_SYMBOL(genphy_read_status);
  
@@ -60,7 +67,20 @@ index 6144146aec29..072a6e515dfa 100644
  /**
   * genphy_soft_reset - software reset the PHY via BMCR_RESET bit
   * @phydev: target phy_device struct
-@@ -1664,6 +1694,20 @@ int genphy_soft_reset(struct phy_device *phydev)
+@@ -1664,7 +1694,11 @@
+ {
+ 	int ret;
+ 
+-	ret = phy_set_bits(phydev, MII_BMCR, BMCR_RESET);
++	ret = phy_write(phydev, MII_BMCR, BMCR_RESET);
++	if (ret < 0)
++		return ret;
++	/* re-enable auto-negociation */
++	ret = phy_set_bits(phydev, MII_BMCR, BMCR_ANENABLE);
+ 	if (ret < 0)
+ 		return ret;
+ 
+@@ -1672,6 +1706,20 @@
  }
  EXPORT_SYMBOL(genphy_soft_reset);
  
@@ -81,7 +101,7 @@ index 6144146aec29..072a6e515dfa 100644
  int genphy_config_init(struct phy_device *phydev)
  {
  	int val;
-@@ -1993,12 +2037,13 @@ static struct phy_driver genphy_driver = {
+@@ -2001,12 +2049,13 @@
  	.phy_id		= 0xffffffff,
  	.phy_id_mask	= 0xffffffff,
  	.name		= "Generic PHY",
@@ -96,6 +116,6 @@ index 6144146aec29..072a6e515dfa 100644
  	.suspend	= genphy_suspend,
  	.resume		= genphy_resume,
  	.set_loopback   = genphy_loopback,
+
 -- 
 2.24.0
-


### PR DESCRIPTION
This PR solve issue #22 by reverting the breaking commit [5aeaa36b6823dcc743d858de237e3bc5b7d3e1e2 ](https://github.com/torvalds/linux/commit/). It also re-enabling auto-negotiation after we reset `BMCR` register  to ensure port X001 works at full speed if we plug the cable while the device is running. 

This fix is IMO not perfect, probably it would be better to keep upstream fix (only modify the `BMCR_RESET` bit) and add some code to set/reset the needed bit, but as I don't have any deep knowledge on how the KSZ886X works with it's interface, how it's initialize, etc ... it's already a start. 

This was tested today with a new build (kernel 4.19.271-rt120+) from the repo. 

Note that this patch won't work for kernel >5.x as there was some rework in the `phy` subsystem. I've also notice while testing with kernel 5.10.x that the DVI port doesn't work anymore. 

Let me know if you want some rework on the patch, comments etc ... 